### PR TITLE
Parse Loop Headers

### DIFF
--- a/src/antlr/pythongrammar.g4
+++ b/src/antlr/pythongrammar.g4
@@ -10,14 +10,15 @@ grammar pythongrammar;
 
 // PARSER RULES:
 comment: COMMENT ;
-// Parse functions like range(0,6) and str(integer). cases such as print(str(integer)) do not parse correctly
+// Parse functions like range(0,6) and str(integer).
 function: FUNCTION OPEN_PAREN expr+ (','+expr)* CLOSE_PAREN ;
-if_rule: IF_STATEMENT OPEN_PAREN? expr CLOSE_PAREN? COLON  block?;
-elif_rule: ELIF_STATEMENT expr COLON  block?;
-else_rule: ELSE_STATEMENT COLON  block?;
+// Loops.
+while_loop: WHILE expr ('and' expr)* COLON block;
+for_loop: FOR ID IN function COLON block;
+loop: while_loop | for_loop;
 
 // Rule for entire python program
-program: (expr | comment)+ EOF;
+program: (expr | comment | loop | if_rule)+ EOF;
 expr: expr ARITHMETIC expr
     | expr CONDITIONAL expr
     | expr ASSIGNMENT expr
@@ -27,11 +28,14 @@ expr: expr ARITHMETIC expr
     | function
     ;
 // RULES in progress:
+if_rule: IF_STATEMENT OPEN_PAREN? expr CLOSE_PAREN? COLON  block?;
+elif_rule: ELIF_STATEMENT expr COLON  block?;
+else_rule: ELSE_STATEMENT COLON  block?;
 prule: ifelseelif block+;
 controlFlow: ifelseelif;
-loop: ;
 
-block: (TAB CHAR+ NEWLINE)+;
+
+block: (TAB expr)+;
 ifelseelif: if_rule (elif_rule)* (else_rule)?;
 
 // LEXER RULES:
@@ -39,8 +43,11 @@ COMMENT: '#' ~('\n' )+;
 IF_STATEMENT: 'if';
 ELIF_STATEMENT: 'elif';
 ELSE_STATEMENT: 'else';
+WHILE: 'while';
+FOR: 'for';
+IN: 'in';
 // 3 Functions used in the test code
-FUNCTION: 'print' | 'range' | 'str';
+FUNCTION: 'print' | 'range' | 'str' | 'int';
 
 ARITHMETIC  : '*'
             | '/'
@@ -62,6 +69,7 @@ CONDITIONAL : '=='
             | '>='
             | '<'
             | '<='
+            | '!='
             | 'and'
             | 'or'
             | 'not'
@@ -73,8 +81,8 @@ TAB: '\t' | '    ';
 OPEN_PAREN: '(';
 CLOSE_PAREN: ')';
 
-QUOTE: '"'|'\'';
-STRING: QUOTE [\u0000-\u00FF]* QUOTE;
+STRING : '"' (~('"'))* '"' ;
+
 WHITESPACE: ' ' -> skip;
 COLON: ':';
 NEWLINE: '\n' -> skip;


### PR DESCRIPTION
This patch works to parse for and while loop headers. 
Also, the lexer rule for a string was adjusted in order to match the next closet string instead of the last string found